### PR TITLE
Windows equivalent commands in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,11 @@
 {
   "scripts": {
-    "start": "NODE_ENV=development snowpack dev",
-    "start:win": "SET NODE_ENV=development && snowpack dev",
+    "start": "snowpack dev",
     "build": "snowpack build",
     "test": "web-test-runner \"src/**/*.test.tsx\"",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
-    "storybook": "NODE_ENV=development start-storybook -p 6006",
-    "storybook:win": "SET NODE_ENV=development && start-storybook -p 6006",
+    "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "scripts": {
     "start": "NODE_ENV=development snowpack dev",
+    "start:win": "SET NODE_ENV=development && snowpack dev",
     "build": "snowpack build",
     "test": "web-test-runner \"src/**/*.test.tsx\"",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
     "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
     "storybook": "NODE_ENV=development start-storybook -p 6006",
+    "storybook:win": "SET NODE_ENV=development && start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },
   "dependencies": {


### PR DESCRIPTION
I'm developing on a windows box at the moment. All of my linux boxes are currently headless. So I had to add some windows equivalent dev commands for its goofy way of handling env variables.