### PR TITLE
Quick and dirty popup details for node markers

### DIFF
--- a/src/Components/DataTable/TableEntry.tsx
+++ b/src/Components/DataTable/TableEntry.tsx
@@ -96,7 +96,7 @@ const TableEntry = (props: TableEntryProps) => {
           >
             <div className="bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-200 flex sm:px-1 md:px-5 shadow-inner w-full space-x-4 py-4">
               <div className="flex">
-                <ChipIcon className="w-5 h-5" />
+                <ChipIcon className="w-5 h-5 my-auto" />
               </div>
               <div className="text-xl font-medium">
                 {props.node.user?.longName}

--- a/src/Components/DataTable/TableEntry.tsx
+++ b/src/Components/DataTable/TableEntry.tsx
@@ -96,7 +96,7 @@ const TableEntry = (props: TableEntryProps) => {
           >
             <div className="bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-gray-200 flex sm:px-1 md:px-5 shadow-inner w-full space-x-4 py-4">
               <div className="flex">
-                <ChipIcon className="w-5 h-5 my-auto" />
+                <ChipIcon className="w-5 h-5" />
               </div>
               <div className="text-xl font-medium">
                 {props.node.user?.longName}


### PR DESCRIPTION
Very bare-bones implementation of popup for node markers. I used some of the examples from mapboxGL's docs to get us a start.
Fixes #2 

![image](https://user-images.githubusercontent.com/9000580/115155245-9bf9ed00-a044-11eb-9931-f982996a0c0b.png)
